### PR TITLE
perf(data_processor): prefer idiomatic pandas for process_metadata

### DIFF
--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -7,11 +7,9 @@ def process_metadata(entries):
     """
     Processes metadata into a Pandas DataFrame (mediaId, score).
     """
-    metadata_list = []
-    for entry in entries:
-        metadata_list.append(pd.DataFrame({"media_id": [entry["mediaId"]], "score": [entry["score"]]}))
-    metadata_df = pd.concat(metadata_list, ignore_index=True)
-    return metadata_df
+    return pd.DataFrame.from_records(entries, columns=["mediaId", "score"]).rename(
+        columns={"mediaId": "media_id"},
+    )
 
 
 def process_data(entries):

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,13 @@
+from src.data_processor import process_metadata
+
+
+def test_process_metadata():
+    entries = (
+        {"mediaId": 1, "score": 10, "irrelevant_key": 0},
+        {"mediaId": 2, "score": 9, "irrelevant_key": 0, "invalid_key": None},
+    )
+    metadata_df = process_metadata(entries)
+    assert metadata_df.columns.tolist() == ["media_id", "score"]
+    assert metadata_df.shape == (2, 2)
+    assert metadata_df["media_id"].tolist() == [1, 2]
+    assert metadata_df["score"].tolist() == [10, 9]


### PR DESCRIPTION
"It is not recommended to build DataFrames by adding single rows in a for loop." ([pd.concat docs](https://pandas.pydata.org/docs/reference/api/pandas.concat.html))

The speed-up is apparent:

<img width="666" alt="image" src="https://github.com/user-attachments/assets/05e3cd8b-f4e5-4e6e-90b2-9980c78c2924">

[performance_demo.ipynb.zip](https://github.com/user-attachments/files/17157217/performance_demo.ipynb.zip)
